### PR TITLE
generated files should not be in distribution

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -15,6 +15,11 @@ my $b = Module::Build->new
     'Test::More'       =>0,
    },
   configure_requires => {'Module::Build' => 0.4224},
+  meta_merge => {
+    resources => {
+      repository => 'https://github.com/philiprbrenan/DataDFA',
+    },
+  },
   create_readme =>  0,
   perl          => '5.26.0',
  );

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,13 +1,3 @@
-_build/auto_features
-_build/build_params
-_build/cleanup
-_build/config_data
-_build/features
-_build/magicnum
-_build/notes
-_build/prereqs
-_build/runtime_params
-Build
 Build.PL
 CHANGES
 lib/Data/DFA.pm


### PR DESCRIPTION
Archive has read-only files, it prevents building.